### PR TITLE
fix .gitmodules to use public submodule repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 
 [submodule "nodes/firmware/RIOT"]
 	path = nodes/firmware/RIOT
-	url = git@git.inet.haw-hamburg.de:user/rottleuthner/riot.git
+	url = git@github.com:smartuni/riot-fork-po-2026.git


### PR DESCRIPTION
## Description

update .gitmodules to use public repo url for the riot submodule

## Related Issue

Closes: #12 

## Type of Change

- [x ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Documentation update

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md).
- [ ] My code follows the project’s style and conventions.
- [ ] I have added or updated tests where applicable.
- [ ] All existing and new tests pass.

## Reviewer Guidelines

- **Code Quality:** Check for naming conventions, modularity, and readability.
- **Functionality:** Verify the feature/bugfix works as intended.
- **Documentation:** Ensure any new behavior is documented (README, code comments).
- [ ] Approve if all checks pass.
