### PR TITLE
3: Fix Docker after Vite migration

### DIFF
--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       context: ./frontend
       target: development
     ports:
-      - "3000:3000"
+      - "5173:5173"
     volumes:
       # Mount the frontend directory to the container for hot reloading
       - ./frontend:/app

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -26,8 +26,8 @@ services:
       # Force bind to all network interfaces
       - HOST=0.0.0.0
       # Provide the backend URL to the frontend
-      - REACT_APP_BACKEND_URL=http://localhost:8080
-    # Required for Create React App (react-scripts start) to keep the dev server running in a container
+      - VITE_BACKEND_URL=http://localhost:8080
+    # Required for Vite dev server to keep running in a container
     stdin_open: true
     tty: true
     depends_on:

--- a/server/frontend/.gitignore
+++ b/server/frontend/.gitignore
@@ -21,3 +21,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# vite
+.vite

--- a/server/frontend/Dockerfile
+++ b/server/frontend/Dockerfile
@@ -12,9 +12,9 @@ RUN npm install
 # Copy the rest of the application
 COPY . .
 
-EXPOSE 3000
+EXPOSE 5173
 
-CMD ["npm", "start"]
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]
 
 # ==========================================
 # 2. Build Stage

--- a/server/frontend/docker-compose.yml
+++ b/server/frontend/docker-compose.yml
@@ -4,7 +4,7 @@ services:
       context: .
       target: development
     ports:
-      - "3000:3000"
+      - "5173:5173"
     volumes:
       # Mount the local directory to the container for hot reloading
       - .:/app

--- a/server/frontend/vite.config.js
+++ b/server/frontend/vite.config.js
@@ -7,6 +7,10 @@ export default defineConfig(() => {
             outDir: 'build',
         },
         plugins: [react()],
+        server: {
+            host: '0.0.0.0',
+            port: 5173,
+        },
         define: {
             global: 'window',
         },


### PR DESCRIPTION
## Description

Docker was broken after the Vite migration — the dev stage still ran `npm start` (CRA on port 3000) but compose mapped 5173, so the container sent no data.

Four changes:

1. **Dockerfile** — switched dev stage from `npm start` to `npm run dev -- --host 0.0.0.0`, exposed 5173
2. **vite.config.js** — added `server.host: '0.0.0.0'` and `server.port: 5173` so Vite binds to all interfaces inside the container
3. **docker-compose.yml** (both) — port mapping `3000:3000` → `5173:5173`
4. **.gitignore** — added `.vite` cache directory

## Related Issue

Closes #3

## Type of Change

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Documentation update

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] My code follows the project's style and conventions.
- [ ] I have added or updated tests where applicable.
- [ ] All existing and new tests pass.

## Reviewer Guidelines

- **Code Quality:** Check for naming conventions, modularity, and readability.
- **Functionality:** Verify the feature/bugfix works as intended.
- **Documentation:** Ensure any new behavior is documented (README, code comments).
- [ ] Approve if all checks pass.

---

**Things to look out for during review:**

- The `HOST=0.0.0.0` env var in `docker-compose.yml` is now redundant (Vite reads its own `server.host` config, not the env var). Left it in since it's harmless — can clean up separately if desired.