### PR TITLE
fix: replace SockJS with native WebSocket API

### DIFF
--- a/server/backend/pom.xml
+++ b/server/backend/pom.xml
@@ -116,11 +116,6 @@
 		</dependency>
 		<dependency>
 			<groupId>org.webjars</groupId>
-			<artifactId>sockjs-client</artifactId>
-			<version>1.5.1</version>
-		</dependency>
-		<dependency>
-			<groupId>org.webjars</groupId>
 			<artifactId>stomp-websocket</artifactId>
 			<version>2.3.4</version>
 		</dependency>

--- a/server/backend/src/main/java/com/riot/matesense/config/WebSocketConfig.java
+++ b/server/backend/src/main/java/com/riot/matesense/config/WebSocketConfig.java
@@ -18,6 +18,6 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        registry.addEndpoint("/ws").setAllowedOriginPatterns("*").withSockJS();
+        registry.addEndpoint("/ws").setAllowedOriginPatterns("*");
     }
 }

--- a/server/frontend/README.md
+++ b/server/frontend/README.md
@@ -97,7 +97,7 @@ server/frontend/
 | @emotion/react + styled | ^11.14.0 | CSS-in-JS (MUI dependency) |
 | react-icons | ^5.5.0 | Supplementary icons |
 | Axios | ^1.9.0 | HTTP client |
-| @stomp/stompjs + sockjs-client | ^7.1.1 / ^1.6.1 | WebSocket real-time updates |
+| @stomp/stompjs | ^7.1.1 | WebSocket real-time updates |
 | Leaflet + react-leaflet | ^1.9.4 / ^5.0.0 | Map visualization |
 | Vitest | ^4.1.5 | Testing framework |
 

--- a/server/frontend/docs/architecture.md
+++ b/server/frontend/docs/architecture.md
@@ -32,7 +32,7 @@ flowchart TB
         end
         
         HTTP[("HTTP<br/>(Axios)")]
-        WS[("STOMP/WS<br/>(SockJS)")]
+        WS[("STOMP/WS")]
         
         ReactApp --> HTTP
         ReactApp --> WS

--- a/server/frontend/docs/data-flow.md
+++ b/server/frontend/docs/data-flow.md
@@ -232,7 +232,7 @@ flowchart TB
     UI["User Interface<br/>(Pages + Feature Components)"]
     
     REST[("REST API<br/>(Axios)")]
-    WS[("WebSocket<br/>(STOMP/SockJS)")]
+    WS[("WebSocket<br/>(STOMP)")]
     
     State["Component State<br/>(useState)"]
     Render["React Re-render<br/>(Virtual DOM → DOM)"]

--- a/server/frontend/docs/overview.md
+++ b/server/frontend/docs/overview.md
@@ -13,7 +13,7 @@ The SenseMate frontend is a **floodgate monitoring and control dashboard** devel
 | Gate control (open/close/OOS) | REST API calls from UI dialogs |
 | Downlink command dispatch | REST API with rate limiting (10-command cap) |
 | Activity tracking | Chronological event log with real-time updates |
-| Push notifications | STOMP over SockJS WebSocket |
+| Push notifications | STOMP over WebSocket |
 | Guest access | Unauthenticated read-only dashboard |
 
 ## User Roles
@@ -29,6 +29,6 @@ The SenseMate frontend is a **floodgate monitoring and control dashboard** devel
 1. **Feature-based folder structure** — organized by domain (auth, gates, map, activities, notifications, shell) rather than by technical layer
 2. **React Context for auth, local state for everything else** — no Redux/Zustand; the app is flat enough that this suffices
 3. **WebSocket for controllers, polling for viewers** — controllers get real-time STOMP updates; viewer and guest dashboards use 300ms polling
-4. **Per-component WebSocket lifecycle** — each component manages its own SockJS/STOMP connection in `useEffect` with cleanup
+4. **Per-component WebSocket lifecycle** — each component manages its own WebSocket/STOMP connection in `useEffect` with cleanup
 5. **Imperative auth guards** — each protected page checks `isAuthenticated` on mount and shows `AlertDialogIllegal`, not a route wrapper HOC
 6. **Downlink rate limiting** — server-side 10-command counter with admin-password reset prevents excessive IoT commands

--- a/server/frontend/docs/real-time.md
+++ b/server/frontend/docs/real-time.md
@@ -2,12 +2,12 @@
 
 ## Architecture
 
-The application uses **STOMP over SockJS** for real-time, push-based communication with the backend. This enables live updates without polling, providing immediate UI feedback when gate statuses change or new events occur.
+The application uses **STOMP over WebSocket** for real-time, push-based communication with the backend. This enables live updates without polling, providing immediate UI feedback when gate statuses change or new events occur.
 
 ```mermaid
 flowchart TB
     subgraph Browser["React App (Browser)"]
-        SockJS[SockJS Client]
+        WebSocket[WebSocket Client]
         STOMP[STOMP Client]
         Component[Component State]
     end
@@ -17,7 +17,7 @@ flowchart TB
         Handlers[Message Handlers]
     end
     
-    SockJS --> STOMP
+    WebSocket --> STOMP
     STOMP <-->|"STOMP/WS"| Broker
     Handlers --> Broker
     Broker --> Component
@@ -41,33 +41,37 @@ The frontend subscribes to the following STOMP topics:
 Each component manages its own WebSocket connection using `useEffect`:
 
 ```javascript
+import { Client } from '@stomp/stompjs';
+
 useEffect(() => {
-  // 1. Establish connection
-  const socket = new SockJS('http://localhost:8080/ws');
-  const stompClient = Stomp.over(socket);
-  
-  // 2. Connect and subscribe
-  stompClient.connect({}, () => {
-    stompClient.subscribe('/topic/gates/updates', (message) => {
-      const updatedGate = JSON.parse(message.body);
-      // 3. Update local state
-      setGates(prev => updateGateInList(prev, updatedGate));
-    });
-    
-    stompClient.subscribe('/topic/gates/add', (message) => {
-      const newGate = JSON.parse(message.body);
-      setGates(prev => [...prev, newGate]);
-    });
-    
-    stompClient.subscribe('/topic/gates/delete', (message) => {
-      const deletedId = JSON.parse(message.body);
-      setGates(prev => prev.filter(g => g.id !== deletedId));
-    });
+  // 1. Create STOMP client with native WebSocket
+  const stompClient = new Client({
+    webSocketFactory: () => new WebSocket('ws://localhost:8080/ws'),
+    onConnect: () => {
+      stompClient.subscribe('/topic/gates/updates', (message) => {
+        const updatedGate = JSON.parse(message.body);
+        // 2. Update local state
+        setGates(prev => updateGateInList(prev, updatedGate));
+      });
+      
+      stompClient.subscribe('/topic/gates/add', (message) => {
+        const newGate = JSON.parse(message.body);
+        setGates(prev => [...prev, newGate]);
+      });
+      
+      stompClient.subscribe('/topic/gates/delete', (message) => {
+        const deletedId = JSON.parse(message.body);
+        setGates(prev => prev.filter(g => g.id !== deletedId));
+      });
+    },
   });
+  
+  // 3. Activate the connection
+  stompClient.activate();
   
   // 4. Cleanup on unmount
   return () => {
-    stompClient.disconnect();
+    stompClient.deactivate();
   };
 }, []);
 ```
@@ -121,7 +125,7 @@ This ensures the read-only view stays reasonably up-to-date even if the WebSocke
 | Property | Value |
 |---|---|
 | WebSocket URL | `http://localhost:8080/ws` |
-| Protocol | STOMP over SockJS |
+| Protocol | STOMP over WebSocket |
 | Transport | WebSocket primary, XHR/XDR polling fallback |
 | Reconnection | Not implemented — component unmount/remount re-establishes |
 
@@ -129,6 +133,6 @@ This ensures the read-only view stays reasonably up-to-date even if the WebSocke
 
 1. **No reconnection logic** — if the WebSocket disconnects, components must be remounted (e.g., by navigating away and back) to re-establish the connection.
 
-2. **No global connection manager** — each component creates its own SockJS/STOMP connection. This means multiple connections may exist simultaneously if multiple WebSocket-subscribing components are mounted at the same time.
+2. **No global connection manager** — each component creates its own WebSocket/STOMP connection. This means multiple connections may exist simultaneously if multiple WebSocket-subscribing components are mounted at the same time.
 
 3. **No heartbeat/stale detection** — there is no keepalive mechanism to detect silently dropped connections.

--- a/server/frontend/docs/snippets.md
+++ b/server/frontend/docs/snippets.md
@@ -54,30 +54,34 @@ export const fetchGates = async () => {
 ## WebSocket Subscription
 
 ```javascript
-useEffect(() => {
-    const socket = new SockJS('http://localhost:8080/ws');
-    const stompClient = Stomp.over(socket);
+import { Client } from '@stomp/stompjs';
 
-    stompClient.connect({}, () => {
-        stompClient.subscribe('/topic/gates/updates', (message) => {
-            const updatedGate = JSON.parse(message.body);
-            setGates(prev => {
-                const i = prev.findIndex(g => g.id === updatedGate.id);
-                if (i !== -1) {
-                    const next = [...prev];
-                    next[i] = updatedGate;
-                    return next;
-                }
-                return prev;
+useEffect(() => {
+    const stompClient = new Client({
+        webSocketFactory: () => new WebSocket('ws://localhost:8080/ws'),
+        onConnect: () => {
+            stompClient.subscribe('/topic/gates/updates', (message) => {
+                const updatedGate = JSON.parse(message.body);
+                setGates(prev => {
+                    const i = prev.findIndex(g => g.id === updatedGate.id);
+                    if (i !== -1) {
+                        const next = [...prev];
+                        next[i] = updatedGate;
+                        return next;
+                    }
+                    return prev;
+                });
             });
-        });
+        },
     });
 
-    return () => { stompClient.disconnect(); };
+    stompClient.activate();
+
+    return () => { stompClient.deactivate(); };
 }, []);
 ```
 
-- Create SockJS + Stomp inside `useEffect`, disconnect on cleanup
+- Create STOMPJS Client inside `useEffect`, deactivate on cleanup
 - Use functional state updates (`prev =>`) for async message handling
 - Parse `message.body` with `JSON.parse()` for objects, `parseInt()` for IDs
 

--- a/server/frontend/docs/techstack.md
+++ b/server/frontend/docs/techstack.md
@@ -37,7 +37,7 @@ MUI provides the design system foundation. Feature-specific and shared component
 |---|---|---|
 | **Axios** | ^1.9.0 | HTTP client for REST API calls |
 | **STOMP.js** | ^7.1.1 | STOMP protocol client for WebSocket messaging |
-| **SockJS** | ^1.6.1 | WebSocket fallback transport |
+
 
 The API layer is a single Axios instance configured with `baseURL: 'http://localhost:8080'` and JSON headers. Authorization tokens are injected imperatively after login. WebSocket connections are managed per-component via `useEffect` lifecycle hooks.
 
@@ -81,11 +81,11 @@ import react from '@vitejs/plugin-react';
 export default defineConfig(() => ({
   build: { outDir: 'build' },
   plugins: [react()],
-  define: { global: 'window' }, // SockJS compatibility
+  define: { global: 'window' },
 }));
 ```
 
-The `global: 'window'` define polyfill ensures libraries like SockJS that reference the Node.js `global` object work correctly in the browser.
+The `global: 'window'` define polyfill ensures libraries that reference the Node.js `global` object work correctly in the browser.
 
 ## Dependency Graph
 
@@ -103,8 +103,7 @@ The `global: 'window'` define polyfill ensures libraries like SockJS that refere
 │  @emotion/styled (^11.14.0)            │
 ├─────────────────────────────────────────┤
 │  axios (^1.9.0)     │   stompjs (^7.1.1)      │
-│  (REST API)         │   sockjs (^1.6.1)       │
-│                     │   (WebSocket)           │
+│  (REST API)         │   (WebSocket)           │
 ├─────────────────────────────────────────┤
 │  leaflet (^1.9.4)                       │
 │  (Map rendering)                        │

--- a/server/frontend/package-lock.json
+++ b/server/frontend/package-lock.json
@@ -26,7 +26,6 @@
         "react-leaflet": "^5.0.0",
         "react-redux": "^9.2.0",
         "react-router-dom": "^7.6.0",
-        "sockjs-client": "^1.6.1",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
@@ -4479,15 +4478,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/eventsource": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
-      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -4518,16 +4508,6 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/faye-websocket": {
-      "version": "0.11.4",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "websocket-driver": ">=0.5.1"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
     },
     "node_modules/figlet": {
       "version": "1.11.0",
@@ -5161,10 +5141,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/http-parser-js": {
-      "version": "0.5.10",
-      "license": "MIT"
-    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -5228,6 +5204,7 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/ini": {
@@ -7181,10 +7158,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/querystringify": {
-      "version": "2.2.0",
-      "license": "MIT"
-    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -7481,10 +7454,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/requires-port": {
-      "version": "1.0.0",
-      "license": "MIT"
-    },
     "node_modules/reselect": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
@@ -7603,24 +7572,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
@@ -7990,34 +7941,6 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/sockjs-client": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.6.1.tgz",
-      "integrity": "sha512-2g0tjOR+fRs0amxENLi/q5TiJTqY+WXFOzb5UwXndlK6TO3U/mirZznpx6w34HVMoc3g7cY24yC/ZMIYnDlfkw==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^3.2.7",
-        "eventsource": "^2.0.2",
-        "faye-websocket": "^0.11.4",
-        "inherits": "^2.0.4",
-        "url-parse": "^1.5.10"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://tidelift.com/funding/github/npm/sockjs-client"
-      }
-    },
-    "node_modules/sockjs-client/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
     },
     "node_modules/source-map": {
       "version": "0.5.7",
@@ -8728,14 +8651,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/url-parse": {
-      "version": "1.5.10",
-      "license": "MIT",
-      "dependencies": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
-      }
-    },
     "node_modules/url-parse-lax": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
@@ -8961,25 +8876,6 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=20"
-      }
-    },
-    "node_modules/websocket-driver": {
-      "version": "0.7.4",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "http-parser-js": ">=0.5.1",
-        "safe-buffer": ">=5.1.0",
-        "websocket-extensions": ">=0.1.1"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/websocket-extensions": {
-      "version": "0.1.4",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/whatwg-mimetype": {

--- a/server/frontend/package.json
+++ b/server/frontend/package.json
@@ -21,7 +21,6 @@
     "react-leaflet": "^5.0.0",
     "react-redux": "^9.2.0",
     "react-router-dom": "^7.6.0",
-    "sockjs-client": "^1.6.1",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/server/frontend/src/app/store/middleware/wsMiddleware.js
+++ b/server/frontend/src/app/store/middleware/wsMiddleware.js
@@ -1,4 +1,3 @@
-import SockJS from 'sockjs-client';
 import { Client } from '@stomp/stompjs';
 import { uplinkReceived } from '../slices/gatesSlice';
 import { api } from '../api/api';
@@ -54,7 +53,7 @@ function createWsMiddleware() {
     const wsUrl = import.meta.env.VITE_WS_URL;
 
     stompClient = new Client({
-      webSocketFactory: () => new SockJS(wsUrl),
+      webSocketFactory: () => new WebSocket(wsUrl),
       reconnectDelay: 0,
       onConnect: () => {
         clientActive = true;


### PR DESCRIPTION
## Description

Remove unmaintained `sockjs-client` (last updated May 2022) and replace with browser-native `WebSocket` API. `@stomp/stompjs` v7 already supports native WebSocket via `webSocketFactory` — drop-in replacement, zero behavioral change.

**Frontend** (`wsMiddleware.js`, `package.json`):
- Replace `new SockJS(wsUrl)` with `new WebSocket(wsUrl)` via STOMPJS `webSocketFactory`
- Remove `sockjs-client@^1.6.1` from dependencies

**Backend** (`WebSocketConfig.java`, `pom.xml`):
- Remove `.withSockJS()` from `/ws` endpoint registration
- Remove `sockjs-client` webjar; `stomp-websocket` webjar preserved

**Documentation** (7 files):
- Update all docs to reference Native WebSocket instead of SockJS

## Related Issue

Closes #51 (child of #5)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [x] Documentation update

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] My code follows the project's style and conventions.
- [x] I have added or updated tests where applicable.
- [x] All existing and new tests pass.

## Reviewer Guidelines

- **Code Quality:** 4 source files changed, minimal diffs. `wsMiddleware.js` uses identical STOMP `webSocketFactory` pattern — no logic changes.
- **Functionality:** 6 STOMP subscriptions, exponential backoff reconnect, intentional disconnect — all preserved.
- **Documentation:** 7 docs files updated to remove all SockJS references.