### PR TITLE
feat(RIOT submodule): better support seeedstudio-xiao-nrf52840-sense

### DIFF
--- a/nodes/firmware/applications/senseMate/Makefile
+++ b/nodes/firmware/applications/senseMate/Makefile
@@ -2,6 +2,8 @@
 APPLICATION = SenseMate
 # If no BOARD is found in the environment, use this default:
 BOARD ?= adafruit-feather-nrf52840-sense
+# TODO: adjust PINs
+# BOARD ?= seeedstudio-xiao-nrf52840-sense
 
 PROJECT_BASE ?= $(CURDIR)/../..
 RIOTBASE ?= $(PROJECT_BASE)/RIOT


### PR DESCRIPTION
Switch to branch with better support for `seeedstudio-xiao-nrf52840-sense`, where our firmware compiles.  
See: https://github.com/smartuni/riot-fork-po-2026/commits/XIAOSenseMate-pwmFeatures/