### PR TITLE
feat(backend): fully disable CORS for HTTP and WebSocket

### DIFF
--- a/server/backend/src/main/java/com/riot/matesense/config/SecurityConfig.java
+++ b/server/backend/src/main/java/com/riot/matesense/config/SecurityConfig.java
@@ -5,7 +5,6 @@ import com.riot.matesense.security.JwtAuthenticationFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -21,9 +20,6 @@ public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtFilter;
 
-    @Value("${app.cors.enabled:true}")
-    private boolean corsEnabled;
-
     public SecurityConfig(JwtAuthenticationFilter jwtFilter) {
         this.jwtFilter = jwtFilter;
     }
@@ -31,11 +27,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         return http
-                .cors(cors -> {
-                    if (!corsEnabled) {
-                        cors.disable();
-                    }
-                })
+                .cors(cors -> cors.disable())
                 .csrf(csrf -> {
                     CookieCsrfTokenRepository tokenRepository = CookieCsrfTokenRepository.withHttpOnlyFalse();
                     CsrfTokenRequestAttributeHandler requestHandler = new CsrfTokenRequestAttributeHandler();
@@ -45,7 +37,6 @@ public class SecurityConfig {
                         .ignoringRequestMatchers("/auth/login", "/auth/logout", "/e2e/**");
                 })
                 .authorizeHttpRequests(auth -> auth
-                    // .anyRequest().permitAll()
                     .requestMatchers("/auth/login", "/auth/register", "/auth/logout").permitAll()
                     .requestMatchers("/gates").permitAll()
                     .requestMatchers("/gate-activities").permitAll()

--- a/server/backend/src/main/java/com/riot/matesense/config/WebConfig.java
+++ b/server/backend/src/main/java/com/riot/matesense/config/WebConfig.java
@@ -1,7 +1,5 @@
 package com.riot.matesense.config;
 
-
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
@@ -9,25 +7,16 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 public class WebConfig {
-    // Allowed frontend origins. Overridable per profile (e.g. the e2e profile adds
-    // the Vite/Playwright dev server origin) via app.cors.allowed-origins.
-    @Value("${app.cors.allowed-origins:http://localhost:3000}")
-    private String[] allowedOrigins;
 
     @Bean
     public WebMvcConfigurer corsConfigurer() {
         return new WebMvcConfigurer() {
             @Override
             public void addCorsMappings(CorsRegistry registry) {
-                var mapping = registry.addMapping("/**")
-                        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
-                        .allowedHeaders("*")
-                        .allowCredentials(true);
-                if (java.util.Arrays.asList(allowedOrigins).contains("*")) {
-                    mapping.allowedOriginPatterns("*");
-                } else {
-                    mapping.allowedOrigins(allowedOrigins);
-                }
+                registry.addMapping("/**")
+                        .allowedOriginPatterns("*")
+                        .allowedMethods("*")
+                        .allowedHeaders("*");
             }
         };
     }

--- a/server/backend/src/main/java/com/riot/matesense/config/WebSocketConfig.java
+++ b/server/backend/src/main/java/com/riot/matesense/config/WebSocketConfig.java
@@ -6,7 +6,6 @@ import com.riot.matesense.security.CookieJwtExtractor;
 import com.riot.matesense.security.JwtService;
 import com.riot.matesense.service.AuthService;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.messaging.Message;
@@ -33,9 +32,6 @@ import java.util.Map;
 @Configuration
 @EnableWebSocketMessageBroker
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
-
-    @Value("${app.cors.allowed-origins:http://localhost:3000}")
-    private String[] allowedOrigins;
 
     @Autowired
     @Lazy
@@ -103,13 +99,14 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        var endpoint = registry.addEndpoint("/ws")
+        registry.addEndpoint("/ws")
+                .setAllowedOriginPatterns("*")
                 .addInterceptors(new HandshakeInterceptor() {
                     @Override
                     public boolean beforeHandshake(ServerHttpRequest request,
-                                                  ServerHttpResponse response,
-                                                  WebSocketHandler wsHandler,
-                                                  Map<String, Object> attributes) {
+                                                   ServerHttpResponse response,
+                                                   WebSocketHandler wsHandler,
+                                                   Map<String, Object> attributes) {
                         // Copy the Cookie header from the HTTP upgrade request into
                         // the session attributes so the STOMP CONNECT interceptor can
                         // read the JWT cookie. Browsers send cookies on the WS
@@ -131,10 +128,5 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
                         // no-op
                     }
                 });
-        if (java.util.Arrays.asList(allowedOrigins).contains("*")) {
-            endpoint.setAllowedOriginPatterns("*");
-        } else {
-            endpoint.setAllowedOrigins(allowedOrigins);
-        }
     }
 }

--- a/server/backend/src/main/resources/application-dev.properties
+++ b/server/backend/src/main/resources/application-dev.properties
@@ -21,9 +21,6 @@ logging.level.org.flywaydb=DEBUG
 # MQTT - use test credentials (from application.yml)
 # Override in .env or application-dev.local.properties if needed
 
-# CORS — disabled for local development (allow requests from any origin without preflight checks)
-app.cors.enabled=false
-
 # Web - detailed error messages
 server.error.include-message=always
 server.error.include-binding-errors=always

--- a/server/backend/src/main/resources/application-e2e.properties
+++ b/server/backend/src/main/resources/application-e2e.properties
@@ -25,11 +25,6 @@ spring.flyway.enabled=false
 # Disable MQTT for stable E2E runs
 mqtt.enabled=false
 
-# Allow the Vite/Playwright dev server origin so browser-driven E2E tests
-# (served on :5173) are not blocked by CORS.
-app.cors.allowed-origins=*
-app.cors.enabled=false
-
 # Cookie security — non-HTTPS for local e2e
 app.cookie.secure=false
 

--- a/server/docker-compose.dev.yml
+++ b/server/docker-compose.dev.yml
@@ -2,7 +2,6 @@
 # Usage: docker compose -f docker-compose.yml -f docker-compose.dev.yml up
 #
 # Differences from production compose:
-#   - CORS disabled (app.cors.enabled=false) for easy local frontend dev
 #   - Cookie Secure flag off (HTTP locally)
 #   - Backend runs with dev profile (debug logging, stack traces)
 


### PR DESCRIPTION
## Summary

Fully disables CORS across all three layers (MVC, Spring Security, WebSocket/STOMP) with no conditional flags, no properties, no branching logic.

## Changes

**Java config (commit 1):**
- `WebConfig.java` — `allowedOriginPatterns("*")`, all methods, all headers; removed `@Value` allowedOrigins field
- `SecurityConfig.java` — `cors.disable()` unconditionally; removed `corsEnabled` flag and confusing `if (!corsEnabled)` conditional
- `WebSocketConfig.java` — `setAllowedOriginPatterns("*")` directly; removed `@Value` allowedOrigins field and `if contains("*")` branching

**Properties cleanup (commit 2):**
- `application-dev.properties` — removed dead `app.cors.enabled`
- `application-e2e.properties` — removed dead `app.cors.allowed-origins` and `app.cors.enabled`
- `docker-compose.dev.yml` — removed stale CORS comment

## Verification

- `./mvnw compile` passes clean
- No remaining `app.cors` references in the codebase
- No remaining `allowedOrigins` field references in Java

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)