### PR TITLE
docs(identity_store): Add documentation for the identity_store module

### DIFF
--- a/nodes/firmware/custom-modules/cbor_serialization/include/cbor_serialization.h
+++ b/nodes/firmware/custom-modules/cbor_serialization/include/cbor_serialization.h
@@ -91,8 +91,28 @@ int cbor_serialize_record_no_sig(const table_record_t *record, uint8_t *out, siz
  */
 int cbor_serialize_id_reqres(message_type_t msg_type, signed_identity_t *signed_identity, uint8_t *out, size_t *out_len);
 
+/**
+ * @brief Serialize in CBOR a CBOR encoded public key and key ID, and its signature.
+ *
+ * @param signed_identity Pointer to the signed identity to serialize.
+ * @param out             Pointer to the buffer that holds enough bytes to store the data.
+ * @param out_len         Pointer to the size of @p out, it will return with the amount of used bytes.
+ *
+ * @retval 0 on success
+ * @retval negative value on error
+ */
 int cbor_serialize_signed_public_identity(const signed_identity_t *signed_identity, uint8_t *out, size_t *out_len);
 
+/**
+ * @brief Serialize in CBOR a public or private key and its key ID.
+ *
+ * @param identity Pointer to the identity serialize.
+ * @param out      Pointer to the buffer that holds enough bytes to store the data.
+ * @param out_len  Pointer to the size of @p out, it will return with the amount of used bytes.
+ *
+ * @retval 0 on success
+ * @retval negative value on error
+ */
 int cbor_serialize_identity(const identity_t *identity, uint8_t *out, size_t *out_len);
 
 /**
@@ -160,6 +180,38 @@ int cbor_decode_record(CborValue *array_item, table_record_t *record,
 int cbor_deserialize_id_reqres(const uint8_t *buffer, size_t buffer_len,
                                signed_identity_t *signed_identity, uint8_t *msg_type);
 
+/**
+ * @brief Deserialize a CBOR array containing a public or private key and a key ID.
+ *
+ * @param data              Buffer containing the CBOR data.
+ * @param data_size         Length of @p data.
+ * @param identity_out      Pointer to the identity to populate.
+ *
+ * @retval 0 on success
+ * @retval negative value on error
+ */
 int cbor_deserialize_identity(const uint8_t *data, size_t data_size, identity_t *identity_out);
+
+/**
+ * @brief Deserialize a CBOR array containing a CBOR encoded public key and key ID, and its signature.
+ *
+ * @param data                Buffer containing the CBOR data.
+ * @param data_size           Length of @p data.
+ * @param signed_identity_out Pointer to the signed identity to populate.
+ *
+ * @retval 0 on success
+ * @retval negative value on error
+ */
 int cbor_deserialize_signed_identity(const uint8_t *data, size_t data_size, signed_identity_t *signed_identity_out);
+
+/**
+ * @brief Deserialize a CBOR array containing all necessary data to setup a node.
+ *
+ * @param data                  Buffer containing the CBOR data.
+ * @param data_size             Length of @p data.
+ * @param provisioning_data_out Pointer to the provisioning data struct to populate.
+ *
+ * @retval 0 on success
+ * @retval negative value on error
+ */
 int cbor_deserialize_provisioning_data(const uint8_t *data, size_t data_size, provisioning_data_t *provisioning_data_out);

--- a/nodes/firmware/custom-modules/identity_store/README.md
+++ b/nodes/firmware/custom-modules/identity_store/README.md
@@ -1,0 +1,26 @@
+# `identity_store`
+
+## Overview
+
+The `identity_store` module handles the storage of BLE as well as LoraWAN keys for a node. This keeps the firmware image free of any secrets and unique IDs.
+
+For this it utilizes the external flash storage on the board and serves as an abstraction on the filesystem and directory structure it manages.
+
+This helps to facilitate a key-gossiping mechanism in which the nodes can receive and permanently store other node's public keys which have been signed by the root private key.
+
+It provides functions for:
+* Setting up a node
+* Getting LoraWAN keys
+* Getting the root public key
+* Getting your own key ID
+* Getting your own private identity
+* Getting your own public identity
+* Getting your own signed public identity, which has been signed by the root private key
+* Adding other node's signed public identities, which have been signed by the root private key
+* Getting other node's public identities
+
+## Identities
+
+The identity store operates on what we call `identities`: A pair of either public or private key and a corresponding key ID, which will be used for BLE communication.
+
+A `signed (public) identity` is a pair of a CBOR encoded `intentity` and the signature obtained from signing that data with the root private key.

--- a/nodes/firmware/custom-modules/identity_store/README.md
+++ b/nodes/firmware/custom-modules/identity_store/README.md
@@ -24,3 +24,28 @@ It provides functions for:
 The identity store operates on what we call `identities`: A pair of either public or private key and a corresponding key ID, which will be used for BLE communication.
 
 A `signed (public) identity` is a pair of a CBOR encoded `intentity` and the signature obtained from signing that data with the root private key.
+
+## Storage layout
+
+Itentity files and LoraWAN keys are stored in the following structure on the external flash:
+
+```
+/config
+└─/loramac
+  ├─ joineui
+  ├─ deveui
+  └─ nwkkey
+/identities
+├─/self
+│ ├─ root.pubid
+│ ├─ self.pubid
+│ └─ self.prvid
+├─/valid
+│ ├─ sensemate-001
+│ ├─ sensemate-002
+│ ├─ ...
+│ ├─ sensegate-001
+│ ├─ sensegate-002
+│ └─ ...
+└─/revoked
+```

--- a/nodes/firmware/custom-modules/identity_store/identity_store.c
+++ b/nodes/firmware/custom-modules/identity_store/identity_store.c
@@ -287,6 +287,8 @@ int get_own_node_id(uint8_t *kid_buffer, size_t kid_buffer_size) {
         return -1;
     }
 
+    // TODO: Instead of doing this, check if `kid_buffer` is large enough by comparing
+    // against `kid_buffer_size` and copy the entirety of `identity.kid` into `kid_buffer`.
     memcpy(kid_buffer, identity.kid, kid_buffer_size);
 
     return 0;

--- a/nodes/firmware/custom-modules/identity_store/include/identity_store.h
+++ b/nodes/firmware/custom-modules/identity_store/include/identity_store.h
@@ -36,13 +36,113 @@ typedef struct {
     loramac_keys_t loramac_keys;
 } provisioning_data_t;
 
+/**
+ * @brief Initialize the identity store
+ * 
+ * Initializes the identity store. This includes checking the correct directory structure
+ * and all necessary files are present on the external flash.
+ * If this check fails, it will format the flash, create the directory structure and drop
+ * the user to a shell blocking further execution of the main thread.
+ * The user then will be able to supply the necessary identity information using the
+ * `identity-manager.py` script.
+ * 
+ * @retval 0 on success
+ */
 int identity_store_init(void);
+
+/**
+ * @brief Get the `JoinEUI`, `DevEUI` and `AppKey` keys from the identity store
+ *
+ * @param loramac_keys_out Pointer to the struct to be filled with the loramac keys
+ *
+ * @retval 0 on success
+ * @retval negative value on error
+ */
 int get_loramac_keys(loramac_keys_t *loramac_keys_out);
+
+/**
+ * @brief Get the root "CA" public key and key ID from the identity store
+ *
+ * @param identity_out Pointer to struct to be filled with the root identity
+ *
+ * @retval 0 on success
+ * @retval negative value on error
+ */
 int get_root_identity(identity_t *identity_out);
+
+/**
+ * @brief Get the key ID of this node from the identity store
+ *
+ * @param kid_buffer      Pointer to the key ID buffer
+ * @param kid_buffer_size Size of the buffer
+ *
+ * @retval 0 on success
+ * @retval negative value on error
+ */
 int get_own_node_id(uint8_t *kid_buffer, size_t kid_buffer_size);
+
+/**
+ * @brief Get private key and key ID of this node from the identity store
+ *
+ * @param identity_out Pointer to struct to be filled with the private identity
+ *
+ * @retval 0 on success
+ * @retval negative value on error
+ */
 int get_own_private_identity(identity_t *identity_out);
+
+/**
+ * @brief Get public key and key ID of this node from the identity store
+ *
+ * @param identity_out Pointer to struct to be filled with this node's public identity
+ *
+ * @retval 0 on success
+ * @retval negative value on error
+ */
 int get_own_public_identity(identity_t *identity_out);
+
+/**
+ * @brief Get the CBOR encoded public identity of this node and the signature over that data from the identity store
+ *
+ * @param signed_identity_out Pointer to struct to be filled with this node's signed public identity
+ *
+ * @retval 0 on success
+ * @retval negative value on error
+ */
 int get_own_signed_public_identity(signed_identity_t *signed_identity_out);
+
+/**
+ * @brief Add a signed public identity (of another node) to the identity store
+ *
+ * @param signed_identity Pointer to struct holding the signed public identity
+ *
+ * @retval 0 on success
+ * @retval negative value on error
+ */
 int add_signed_public_identity(const signed_identity_t *signed_identity);
+
+/**
+ * @brief Initialize a `vfs_DIR` struct to use with `get_public_identities_next`
+ *
+ * @param dirp Pointer to uninitialized `vfs_DIR` struct 
+ *
+ * @retval 0 on success
+ * @retval negative value on error
+ */
 int get_public_identities_init(vfs_DIR *dirp);
+
+/**
+ * @brief Get the next public key and key ID from the identity store
+ * 
+ * This function uses a `vfs_DIR` struct initialized by `get_public_identities_init` to keep a reference
+ * to the directory public identities are stored in on the stack.
+ * So be sure to call that function before this one.
+ *
+ * @param dirp Pointer to `vfs_DIR` struct initialized with `get_public_identities_init`
+ * @param identity_out Pointer to struct to be filled with the next public identity in the identity store
+ *
+ * @retval positive value when the next public identity was successfully read
+ * @retval 0 when the end has been reached
+ * @retval negative value on error
+ */
 int get_public_identities_next(vfs_DIR *dirp, identity_t *identity_out);


### PR DESCRIPTION
Adds a README and documentation for each function in the identity_store module, as well as documentation for functions related to it in the cbor_serialization module.